### PR TITLE
Fix device info message port initialization

### DIFF
--- a/components/Contador.brs
+++ b/components/Contador.brs
@@ -19,6 +19,8 @@ sub init()
   ' Inicializar timer de clima
   iniciarTimerClima()
 
+  ' Criar porta de mensagens para eventos do dispositivo
+  m.port = CreateObject("roMessagePort")
   m.deviceInfo = CreateObject("roDeviceInfo")
   m.deviceInfo.SetMessagePort(m.port)
   m.deviceInfo.EnableLinkStatusEvent(true)


### PR DESCRIPTION
## Summary
- create a message port in `Contador` before assigning it to `roDeviceInfo`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f67c76f50832e9309004f1214a56e